### PR TITLE
Improve RoadRunner detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## Unreleased
+
+### Added
+
+- Support of RoadRunner env `RR_MODE`
+
 ## v1.4.0
 
 ### Added

--- a/functions/dump.php
+++ b/functions/dump.php
@@ -26,6 +26,11 @@ if (! \function_exists('\\dev\\ran_using_cli')) {
         if (((bool) \getenv('RR_HTTP')) === true) {
             return false;
         }
+        
+        // Detect running under RoadRunner (since RR v2)
+        if (\getenv('RR_MODE') === 'http') {
+            return true;   
+        }
 
         return \in_array(\PHP_SAPI, ['cli', 'phpdbg'], true);
     }

--- a/functions/dump.php
+++ b/functions/dump.php
@@ -29,7 +29,7 @@ if (! \function_exists('\\dev\\ran_using_cli')) {
         
         // Detect running under RoadRunner (since RR v2)
         if (\getenv('RR_MODE') === 'http') {
-            return true;   
+            return false;   
         }
 
         return \in_array(\PHP_SAPI, ['cli', 'phpdbg'], true);


### PR DESCRIPTION
RoadRunner uses `RR_MODE=http` env variable according to https://roadrunner.dev/docs/php-environment since v2.


Closes #8 