### PR TITLE
Laravel 9 Support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,9 +21,9 @@ jobs: # Docs: <https://git.io/JvxXE>
         setup: [basic, lowest]
         laravel: [default]
         coverage: [yes]
-        php: ['7.2', '7.3', '7.4', '8.0']
+        php: ['8.0']
         include:
-          - php: '7.3'
+          - php: '8.0'
             setup: basic
             coverage: no
             laravel: '^7.0'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,6 +27,7 @@ jobs: # Docs: <https://git.io/JvxXE>
             setup: basic
             coverage: no
             laravel: '^7.0'
+
           - php: '8.0'
               setup: basic
               coverage: no

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,9 +21,9 @@ jobs: # Docs: <https://git.io/JvxXE>
         setup: [basic, lowest]
         laravel: [default]
         coverage: [yes]
-        php: ['8.0']
+        php: ['7.2', '7.3', '7.4', '8.0']
         include:
-          - php: '8.0'
+          - php: '7.3'
             setup: basic
             coverage: no
             laravel: '^7.0'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,7 +58,7 @@ jobs: # Docs: <https://git.io/JvxXE>
 
       - name: Install specific laravel version
         if: matrix.laravel != 'default'
-        run: composer require --dev --update-with-dependencies --prefer-dist --ansi laravel/laravel "${{ matrix.laravel }}"
+        run: rm composer.lock && composer require --dev --update-with-dependencies --prefer-dist --ansi laravel/laravel "${{ matrix.laravel }}"
 
       - name: Show most important packages versions
         run: composer info | grep -e laravel -e phpunit -e phpstan

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,6 +27,10 @@ jobs: # Docs: <https://git.io/JvxXE>
             setup: basic
             coverage: no
             laravel: '^7.0'
+          - php: '8.0'
+              setup: basic
+              coverage: no
+              laravel: '^9.0'
     steps:
       - name: Check out code
         uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,7 +58,7 @@ jobs: # Docs: <https://git.io/JvxXE>
 
       - name: Install specific laravel version
         if: matrix.laravel != 'default'
-        run: rm composer.lock && composer require --dev --update-with-dependencies --prefer-dist --ansi laravel/laravel "${{ matrix.laravel }}"
+        run: composer require --dev --update-with-dependencies --prefer-dist --ansi laravel/laravel "${{ matrix.laravel }}"
 
       - name: Show most important packages versions
         run: composer info | grep -e laravel -e phpunit -e phpstan

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,11 +27,6 @@ jobs: # Docs: <https://git.io/JvxXE>
             setup: basic
             coverage: no
             laravel: '^7.0'
-
-          - php: '8.0'
-              setup: basic
-              coverage: no
-              laravel: '^9.0'
     steps:
       - name: Check out code
         uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
-## v1.6.0
+## UNRELEASED
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## v1.6.0
+
+### Added
+
+- Support Laravel `9.x`
+
 ## v1.5.0
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.2 || ^8.0",
+        "php": "^8.0",
         "illuminate/contracts": "~6.0 || ~7.0 || ~8.0 || ~9.0",
         "illuminate/container": "~6.0 || ~7.0 || ~8.0 || ~9.0",
         "illuminate/support": "~6.0 || ~7.0 || ~8.0 || ~9.0",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^7.2 || ^8.0",
         "illuminate/contracts": "~6.0 || ~7.0 || ~8.0 || ~9.0",
         "illuminate/container": "~6.0 || ~7.0 || ~8.0 || ~9.0",
         "illuminate/support": "~6.0 || ~7.0 || ~8.0 || ~9.0",

--- a/composer.json
+++ b/composer.json
@@ -15,13 +15,13 @@
     ],
     "require": {
         "php": "^7.2 || ^8.0",
-        "illuminate/contracts": "~6.0 || ~7.0 || ~8.0",
-        "illuminate/container": "~6.0 || ~7.0 || ~8.0",
-        "illuminate/support": "~6.0 || ~7.0 || ~8.0",
-        "illuminate/http": "~6.0 || ~7.0 || ~8.0"
+        "illuminate/contracts": "~6.0 || ~7.0 || ~8.0 || ~9.0",
+        "illuminate/container": "~6.0 || ~7.0 || ~8.0 || ~9.0",
+        "illuminate/support": "~6.0 || ~7.0 || ~8.0 || ~9.0",
+        "illuminate/http": "~6.0 || ~7.0 || ~8.0 || ~9.0"
     },
     "require-dev": {
-        "laravel/laravel": "~6.0 || ~7.0 || ~8.0",
+        "laravel/laravel": "~6.0 || ~7.0 || ~8.0 || ~9.0",
         "phpstan/phpstan": "~0.12.34",
         "phpunit/phpunit": "^8.0 || ^9.3"
     },


### PR DESCRIPTION
## Description

Updated `composer.json` to support Laravel 9. No other code changes are required, other than to update the GH actions workflow to delete the `composer.lock` before trying to install a lower version of the framework.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code _(if tests is required for my changes)_
- [x] I have made changes in `CHANGELOG.md` file
